### PR TITLE
Refine KnockbackEngine integration

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -42,7 +42,7 @@ export class CombatCalculator {
         return (dx * facing.x + dy * facing.y) > 0;
     }
 
-    handleAttack(data) {
+    handleAttack(data, context = {}) {
         const { attacker, defender, skill } = data;
         const attackingWeapon = attacker.equipment?.main_hand || attacker.equipment?.weapon;
 
@@ -85,7 +85,9 @@ export class CombatCalculator {
             damageMultiplier = 1.5;
             attacker.effects = attacker.effects.filter(e => e.id !== 'charging_shot_effect');
             this.eventManager.publish('log', { message: `[충전된 사격]이 발동됩니다!`, color: 'magenta' });
-            this.eventManager.publish('knockback_request', { attacker, defender, distance: 128 });
+            if (context.knockbackEngine) {
+                context.knockbackEngine.apply(attacker, defender, 128);
+            }
         }
 
         if (skill && skill.id === 'backstab' && this._isBehind(attacker, defender)) {
@@ -139,6 +141,10 @@ export class CombatCalculator {
                     attacker,
                     weapon: attackingWeapon
                 });
+                const strength = attackingWeapon.knockback || 32;
+                if (context.knockbackEngine) {
+                    context.knockbackEngine.apply(attacker, defender, strength);
+                }
             }
         }
     }

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -13,11 +13,6 @@ export class VFXManager {
         this.eventManager = eventManager;
         this.itemManager = itemManager;
         this.knockbackEffectDuration = 15;
-        if (this.eventManager) {
-            this.eventManager.subscribe('knockback_success', data => {
-                this.addKnockbackEffect(data.attacker, data.weapon);
-            });
-        }
         console.log("[VFXManager] Initialized with Internal Engines");
     }
 
@@ -390,6 +385,20 @@ export class VFXManager {
             color: options.color || 'rgba(255,0,0,0.5)'
         };
         this.effects.push(effect);
+    }
+
+    /**
+     * Knockback visual effect triggered directly by the engine.
+     * @param {number} x
+     * @param {number} y
+     */
+    addKnockbackVisual(x, y) {
+        this.addParticleBurst(x, y, {
+            count: 5,
+            color: 'rgba(255, 255, 255, 0.7)',
+            speed: 3,
+            lifespan: 20
+        });
     }
 
     addKnockbackEffect(attacker, weapon) {

--- a/src/systems/KnockbackEngine.js
+++ b/src/systems/KnockbackEngine.js
@@ -1,0 +1,37 @@
+export class KnockbackEngine {
+    /**
+     * @param {object} motionManager - The MotionManager instance
+     * @param {object} vfxManager - The VFXManager instance
+     */
+    constructor(motionManager, vfxManager) {
+        if (!motionManager || !vfxManager) {
+            throw new Error("KnockbackEngine requires MotionManager and VFXManager");
+        }
+        this.motionManager = motionManager;
+        this.vfxManager = vfxManager;
+        console.log('[KnockbackEngine] Initialized');
+    }
+
+    /**
+     * Applies knockback to a target entity.
+     * @param {object} source - The entity causing the knockback
+     * @param {object} target - The entity receiving the knockback
+     * @param {number} strength - The strength of the knockback (pixels)
+     */
+    apply(source, target, strength) {
+        if (!source || !target || !strength || strength <= 0) {
+            return;
+        }
+
+        const result = this.motionManager.knockbackTarget(target, source, strength);
+        if (!result) return;
+
+        this.vfxManager.addKnockbackAnimation(target, result.fromPos, result.toPos);
+
+        const effectX = target.x + target.width / 2;
+        const effectY = target.y + target.height / 2;
+        if (this.vfxManager.addKnockbackVisual) {
+            this.vfxManager.addKnockbackVisual(effectX, effectY);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- trigger KnockbackEngine directly for charged shots
- remove obsolete `knockback_request` listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857ed6cd5d4832784d3eb4611af4d1d