### PR TITLE
Implement SupportEngine with MBTI logic

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -7,7 +7,7 @@ import { SKILLS } from './data/skills.js';
 // 시각 효과 로직과 분리한다.  실제 팝업 처리는 game.js가 담당한다.
 
 // --- AI 유형(Archetype)의 기반이 될 부모 클래스 ---
-class AIArchetype {
+export class AIArchetype {
     // action은 { type: 'move', target: {x, y} } 또는 { type: 'attack', target: entity } 같은 객체
     decideAction(self, context) {
         // 기본적으로는 아무것도 하지 않음 (자식 클래스에서 재정의)

--- a/src/ai/SupportAI.js
+++ b/src/ai/SupportAI.js
@@ -1,0 +1,40 @@
+import { AIArchetype } from '../ai.js';
+import { SKILLS } from '../data/skills.js';
+
+export class SupportAI extends AIArchetype {
+    /**
+     * @param {object} supportEngine - SupportEngine 인스턴스
+     * @param {object} config - { priorities: ['heal','purify','buff'], buffId: 'effect_id', skillIds?: { heal, purify, buff } }
+     */
+    constructor(supportEngine, config = {}) {
+        super();
+        if (!supportEngine) throw new Error('SupportAI requires a SupportEngine.');
+        this.engine = supportEngine;
+        this.priorities = config.priorities || [];
+        this.buffId = config.buffId || null;
+        const defaults = {
+            heal: SKILLS.heal.id,
+            purify: SKILLS.purify.id,
+            buff: config.buffSkillId || 'buff'
+        };
+        this.skillIds = { ...defaults, ...(config.skillIds || {}) };
+    }
+
+    decideAction(self, context) {
+        const { allies } = context;
+        for (const priority of this.priorities) {
+            let target = null;
+            if (priority === 'heal') {
+                target = this.engine.findHealTarget(self, allies);
+            } else if (priority === 'purify') {
+                target = this.engine.findPurifyTarget(self, allies);
+            } else if (priority === 'buff') {
+                target = this.engine.findBuffTarget(self, allies, this.buffId);
+            }
+            if (target) {
+                return { type: 'skill', target, skillId: this.skillIds[priority] };
+            }
+        }
+        return { type: 'idle' };
+    }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -22,6 +22,7 @@ import { FogManager } from './managers/fogManager.js';
 import { NarrativeManager } from './managers/narrativeManager.js';
 import { TurnManager } from './managers/turnManager.js';
 import { KnockbackEngine } from './systems/KnockbackEngine.js';
+import { SupportEngine } from './systems/SupportEngine.js';
 import { SKILLS } from './data/skills.js';
 import { EFFECTS } from './data/effects.js';
 import { Item } from './entities.js';
@@ -105,7 +106,8 @@ export class Game {
         this.saveLoadManager = new SaveLoadManager();
         this.turnManager = new TurnManager();
         this.narrativeManager = new NarrativeManager();
-        this.factory = new CharacterFactory(assets);
+        this.supportEngine = new SupportEngine();
+        this.factory = new CharacterFactory(assets, this);
 
         // --- 매니저 생성 부분 수정 ---
         this.managers = {};
@@ -1155,6 +1157,7 @@ export class Game {
             equipmentManager: this.equipmentManager,
             vfxManager: this.vfxManager,
             knockbackEngine: this.knockbackEngine,
+            supportEngine: this.supportEngine,
             assets: this.loader.assets,
             metaAIManager,
             microItemAIManager,

--- a/src/systems/SupportEngine.js
+++ b/src/systems/SupportEngine.js
@@ -1,0 +1,78 @@
+export class SupportEngine {
+    constructor() {
+        console.log('[SupportEngine] Initialized');
+    }
+
+    /**
+     * 치유가 필요한 아군을 찾습니다.
+     * @param {object} caster - 시전자
+     * @param {Array<object>} allies - 아군 목록
+     * @returns {object|null} MBTI 성향을 고려해 선택된 아군
+     */
+    findHealTarget(caster, allies) {
+        const mbti = caster.properties?.mbti || '';
+        let threshold = 0.7;
+        if (mbti.includes('S')) {
+            threshold = 0.9;
+        } else if (mbti.includes('N')) {
+            threshold = 0.5;
+        }
+
+        const candidates = allies.filter(
+            a => a.hp < a.maxHp && a.hp / a.maxHp <= threshold
+        );
+        if (candidates.length === 0) return null;
+
+        if (mbti.includes('I')) {
+            return candidates.find(c => c === caster) || candidates[0];
+        }
+
+        if (mbti.includes('E')) {
+            return candidates.reduce((low, cur) =>
+                cur.hp / cur.maxHp < low.hp / low.maxHp ? cur : low,
+                candidates[0]);
+        }
+
+        return candidates[0];
+    }
+
+    /**
+     * 정화가 필요한 아군을 찾습니다.
+     * @param {object} caster - 시전자
+     * @param {Array<object>} allies - 아군 목록
+     * @returns {object|null} 상태 이상이 있는 아군
+     */
+    findPurifyTarget(caster, allies) {
+        const mbti = caster.properties?.mbti || '';
+        const candidates = [caster, ...allies].filter(a =>
+            a.effects?.some(eff => eff.tags?.includes('status_ailment'))
+        );
+        if (candidates.length === 0) return null;
+
+        if (mbti.includes('I')) {
+            return candidates.find(c => c === caster) || candidates[0];
+        }
+        return candidates[0];
+    }
+
+    /**
+     * 특정 버프가 필요한 아군을 찾습니다.
+     * @param {object} caster - 시전자
+     * @param {Array<object>} allies - 아군 목록
+     * @param {string} buffId - 확인할 버프 효과의 ID
+     * @returns {object|null} 지정 버프가 없는 아군
+     */
+    findBuffTarget(caster, allies, buffId) {
+        if (!buffId) return null;
+        const mbti = caster.properties?.mbti || '';
+        const targets = [caster, ...allies].filter(a =>
+            a.hp > 0 && !a.effects?.some(eff => eff.id === buffId)
+        );
+        if (targets.length === 0) return null;
+
+        if (mbti.includes('I')) {
+            return targets.find(t => t === caster) || targets[0];
+        }
+        return targets[0];
+    }
+}


### PR DESCRIPTION
## Summary
- refine SupportEngine so ally selection respects MBTI traits
- update SupportAI defaults using SKILLS constants
- keep tests passing with updated support logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857efa4a3b083279c15d23f1a9bff81