### PR TITLE
Fix knockback near walls

### DIFF
--- a/src/managers/motionManager.js
+++ b/src/managers/motionManager.js
@@ -118,10 +118,22 @@ export class MotionManager {
      */
     knockbackTarget(target, source, distance) {
         const angle = Math.atan2(target.y - source.y, target.x - source.x);
-        const destX = target.x + Math.cos(angle) * distance;
-        const destY = target.y + Math.sin(angle) * distance;
+        const step = this.mapManager.tileSize / 2;
+        const steps = Math.max(1, Math.ceil(distance / step));
 
-        if (this.mapManager.isWallAt(destX, destY, target.width, target.height)) {
+        let destX = target.x;
+        let destY = target.y;
+        for (let i = 1; i <= steps; i++) {
+            const checkX = target.x + Math.cos(angle) * step * i;
+            const checkY = target.y + Math.sin(angle) * step * i;
+            if (this.mapManager.isWallAt(checkX, checkY, target.width, target.height)) {
+                break;
+            }
+            destX = checkX;
+            destY = checkY;
+        }
+
+        if (destX === target.x && destY === target.y) {
             console.log('[MotionManager] 넉백 실패: 목적지에 벽이 있음');
             return null;
         }

--- a/tests/motionManager.test.js
+++ b/tests/motionManager.test.js
@@ -42,4 +42,32 @@ test('pullTargetTo moves target to closest open tile', () => {
     assert.strictEqual(target.y, subject.y + mapManager.tileSize);
 });
 
+test('knockbackTarget stops before hitting a wall', () => {
+    const mapManager = {
+        tileSize: 1,
+        width: 5,
+        height: 5,
+        tileTypes: { FLOOR: 0, WALL: 1 },
+        map: Array.from({ length: 5 }, () => Array(5).fill(0)),
+        isWallAt(x, y) {
+            const mx = Math.floor(x);
+            const my = Math.floor(y);
+            if (mx < 0 || mx >= this.width || my < 0 || my >= this.height) return true;
+            return this.map[my][mx] === this.tileTypes.WALL;
+        }
+    };
+    // Place a wall at x=4
+    mapManager.map[0][4] = 1;
+
+    const pathManager = new PathfindingManager(mapManager);
+    const motion = new MotionManager(mapManager, pathManager, null);
+
+    const source = { x: 0, y: 0 };
+    const target = { x: 2, y: 0, width: 1, height: 1 };
+    const result = motion.knockbackTarget(target, source, 3);
+
+    assert.ok(result, 'knockback result should not be null');
+    assert.deepStrictEqual(result.toPos, { x: 3.5, y: 0 });
+});
+
 });


### PR DESCRIPTION
## Summary
- update `knockbackTarget` so knockback slides up to a wall instead of failing
- add a regression test for the knockback behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f828462483278da82c54cdb8f6b1