### PR TITLE
Improve AoE engine integration

### DIFF
--- a/src/managers/projectileManager.js
+++ b/src/managers/projectileManager.js
@@ -1,13 +1,15 @@
 import { Projectile } from "../entities.js";
 import { findEntitiesInRadius } from '../utils/entityUtils.js';
+import { AreaOfEffectEngine } from '../systems/AreaOfEffectEngine.js';
 
 export class ProjectileManager {
-    constructor(eventManager, assets, vfxManager = null, knockbackEngine = null) {
+    constructor(eventManager, assets, vfxManager = null, knockbackEngine = null, aoeEngine = null) {
         this.projectiles = [];
         this.eventManager = eventManager;
         this.assets = assets;
         this.vfxManager = vfxManager;
         this.knockbackEngine = knockbackEngine;
+        this.aoeEngine = aoeEngine instanceof AreaOfEffectEngine ? aoeEngine : null;
         console.log("[ProjectileManager] Initialized");
     }
 
@@ -94,7 +96,17 @@ export class ProjectileManager {
                         this.vfxManager.addShockwave(impactPos.x, impactPos.y, { maxRadius: radius });
                     }
 
-                    const aoeTargets = findEntitiesInRadius(impactPos.x, impactPos.y, radius, allEntities, result.target);
+                    let aoeTargets;
+                    if (this.aoeEngine) {
+                        aoeTargets = this.aoeEngine.findTargets(
+                            { x: impactPos.x, y: impactPos.y },
+                            allEntities,
+                            'circle',
+                            { radius }
+                        );
+                    } else {
+                        aoeTargets = findEntitiesInRadius(impactPos.x, impactPos.y, radius, allEntities, result.target);
+                    }
                     for (const aoeTarget of aoeTargets) {
                         if (aoeTarget.isFriendly !== proj.caster.isFriendly) {
                             this.eventManager.publish('log', { message: `[음파 화살]이 ${aoeTarget.constructor.name}에게 피해를 입힙니다!`, color: '#add8e6' });

--- a/src/systems/AreaOfEffectEngine.js
+++ b/src/systems/AreaOfEffectEngine.js
@@ -1,0 +1,39 @@
+export class AreaOfEffectEngine {
+    constructor() {
+        console.log('[AreaOfEffectEngine] Initialized');
+    }
+
+    /**
+     * 지정된 형태와 옵션에 따라 범위 내의 타겟들을 찾습니다.
+     * @param {{x: number, y: number}} origin - 범위의 중심점
+     * @param {Array<object>} allEntities - 확인할 모든 엔티티 목록
+     * @param {string} shape - 범위의 모양 ('circle', 'cone' 등)
+     * @param {object} options - 범위의 상세 옵션 (예: { radius: 50 })
+     * @returns {Array<object>} - 범위 내에 있는 엔티티 목록
+     */
+    findTargets(origin, allEntities, shape, options) {
+        const targets = [];
+        switch (shape) {
+            case 'circle':
+                if (!options.radius) {
+                    console.error("AoEEngine: 'circle' shape requires a 'radius' option.");
+                    return [];
+                }
+                for (const entity of allEntities) {
+                    if (!entity.isDying && entity.hp > 0) {
+                        const distance = Math.hypot(entity.x - origin.x, entity.y - origin.y);
+                        if (distance <= options.radius) {
+                            targets.push(entity);
+                        }
+                    }
+                }
+                break;
+            case 'cone':
+                console.warn("AoEEngine: 'cone' shape is not yet implemented.");
+                break;
+            default:
+                console.error(`AoEEngine: Unknown shape '${shape}'`);
+        }
+        return targets;
+    }
+}


### PR DESCRIPTION
## Summary
- inject `AreaOfEffectEngine` into `ProjectileManager`
- use AoE engine when sonic arrow hits
- pass AoE engine from `Game`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858118064d4832787fe804bcfbf1d30