### PR TITLE
Update aquarium maze and wall faces

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -6,8 +6,8 @@ export class AquariumMapManager extends MapManager {
     constructor(seed) {
         super(seed);
         this.name = 'aquarium';
-        // wider passages help observe pathfinding for mercenaries and monsters
-        this.corridorWidth = 8;
+        // narrower corridors make the aquarium feel more like a maze
+        this.corridorWidth = 5;
         // regenerate with the new corridor width
         this.map = this._generateMaze();
     }
@@ -15,5 +15,10 @@ export class AquariumMapManager extends MapManager {
     _generateMaze() {
         // use the base maze generation but with a larger corridor width
         return super._generateMaze();
+    }
+
+    // keep more dead ends so walls are prominent
+    _removeDeadEnds(map, chance) {
+        return super._removeDeadEnds(map, 0.05);
     }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -62,7 +62,7 @@ export class Game {
         this.loader.loadImage('mercenary', 'assets/images/warrior.png');
         this.loader.loadImage('floor', 'assets/floor.png');
         this.loader.loadImage('wall', 'assets/wall.png');
-        this.loader.loadImage('wall_face', 'assets/wall.png');
+        this.loader.loadImage('wall_face', 'assets/images/wall-face.png');
         this.loader.loadImage('gold', 'assets/gold.png');
         this.loader.loadImage('potion', 'assets/potion.png');
         this.loader.loadImage('sword', 'assets/images/shortsword.png');

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -14,7 +14,7 @@ const assets = { monster:{} };
 describe('Aquarium', () => {
     test('Aquarium map uses a wide maze layout', () => {
         const m = new AquariumMapManager(1);
-        assert.ok(m.corridorWidth >= 8, 'corridor width should be wide');
+        assert.strictEqual(m.corridorWidth, 5);
         const wallCount = m.countTiles(m.tileTypes.WALL);
         assert.ok(wallCount > 0 && wallCount < m.width * m.height, 'maze should contain walls and floors');
     });


### PR DESCRIPTION
## Summary
- narrow aquarium corridors for more maze-like feel and keep more dead ends
- use newly uploaded wall-face texture for wall sides
- update test expectations for the new corridor width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581f19a7748327af1f2034abc2aa66