### PR TITLE
Revert object-based map update

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -62,7 +62,7 @@ export class Game {
         this.loader.loadImage('mercenary', 'assets/images/warrior.png');
         this.loader.loadImage('floor', 'assets/floor.png');
         this.loader.loadImage('wall', 'assets/wall.png');
-        this.loader.loadImage('wall_face', 'assets/wall.png');
+        this.loader.loadImage('wall_face', 'assets/images/wall-face.png');
         this.loader.loadImage('gold', 'assets/gold.png');
         this.loader.loadImage('potion', 'assets/potion.png');
         this.loader.loadImage('sword', 'assets/images/shortsword.png');

--- a/src/managers/pathfindingManager.js
+++ b/src/managers/pathfindingManager.js
@@ -41,7 +41,7 @@ export class PathfindingManager {
                 const nKey = `${nx},${ny}`;
 
                 if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
-                if (map[ny][nx].type === tileTypes.WALL || map[ny][nx].type === tileTypes.CHASM) continue;
+                if (map[ny][nx] === tileTypes.WALL) continue;
                 if (isBlocked(nx, ny) && !(nx === endX && ny === endY)) continue;
                 if (visited.has(nKey)) continue;
 
@@ -75,7 +75,7 @@ export class PathfindingManager {
             const nx = endX + dir.x;
             const ny = endY + dir.y;
             if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
-            if (map[ny][nx].type === tileTypes.WALL || map[ny][nx].type === tileTypes.CHASM) continue;
+            if (map[ny][nx] === tileTypes.WALL) continue;
             const path = this._bfs(startX, startY, nx, ny, isBlocked);
             if (path.length > 0 && (bestPath.length === 0 || path.length < bestPath.length)) {
                 bestPath = path;
@@ -106,7 +106,7 @@ export class PathfindingManager {
 
                 if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
                 if (visited.has(key)) continue;
-                if (map[ny][nx].type === tileTypes.WALL || map[ny][nx].type === tileTypes.CHASM) {
+                if (map[ny][nx] === tileTypes.WALL) {
                     visited.add(key);
                     continue;
                 }

--- a/tests/mapManager.test.js
+++ b/tests/mapManager.test.js
@@ -10,7 +10,7 @@ describe('Managers', () => {
     let floorCount = 0;
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
-        if (map[y][x].type !== tileTypes.WALL) {
+        if (map[y][x] !== tileTypes.WALL) {
           if (!startNode) startNode = { x, y };
           floorCount++;
         }
@@ -36,7 +36,7 @@ describe('Managers', () => {
       ];
       for (const n of neighbors) {
         const key = `${n.x},${n.y}`;
-        if (map[n.y] && map[n.y][n.x].type !== tileTypes.WALL && !visited.has(key)) {
+        if (map[n.y] && map[n.y][n.x] !== tileTypes.WALL && !visited.has(key)) {
           visited.add(key);
           queue.push(n);
         }

--- a/tests/motionManager.test.js
+++ b/tests/motionManager.test.js
@@ -10,7 +10,7 @@ test('dashTowards 이동 거리 제한', () => {
         width: 5,
         height: 5,
         tileTypes: { FLOOR: 0, WALL: 1 },
-        map: Array.from({ length: 5 }, () => Array.from({ length: 5 }, () => ({ type: 0 }))),
+        map: Array.from({ length: 5 }, () => Array(5).fill(0)),
         isWallAt: () => false,
     };
     const pathManager = new PathfindingManager(mapManager);
@@ -28,7 +28,7 @@ test('pullTargetTo moves target to closest open tile', () => {
         width: 5,
         height: 5,
         tileTypes: { FLOOR: 0, WALL: 1 },
-        map: Array.from({ length: 5 }, () => Array.from({ length: 5 }, () => ({ type: 0 }))),
+        map: Array.from({ length: 5 }, () => Array(5).fill(0)),
         isWallAt: () => false,
     };
     const pathManager = new PathfindingManager(mapManager);
@@ -48,16 +48,16 @@ test('knockbackTarget stops before hitting a wall', () => {
         width: 5,
         height: 5,
         tileTypes: { FLOOR: 0, WALL: 1 },
-        map: Array.from({ length: 5 }, () => Array.from({ length: 5 }, () => ({ type: 0 }))),
+        map: Array.from({ length: 5 }, () => Array(5).fill(0)),
         isWallAt(x, y) {
             const mx = Math.floor(x);
             const my = Math.floor(y);
             if (mx < 0 || mx >= this.width || my < 0 || my >= this.height) return true;
-            return this.map[my][mx].type === this.tileTypes.WALL;
+            return this.map[my][mx] === this.tileTypes.WALL;
         }
     };
     // Place a wall at x=4
-    mapManager.map[0][4] = { type: 1 };
+    mapManager.map[0][4] = 1;
 
     const pathManager = new PathfindingManager(mapManager);
     const motion = new MotionManager(mapManager, pathManager, null);

--- a/tests/pathfindingManager.test.js
+++ b/tests/pathfindingManager.test.js
@@ -10,18 +10,18 @@ test('생성', () => {
 
 test('단순 경로 탐색', () => {
     const mapManager = {
-        tileTypes: { FLOOR:0, WALL:1 },
         map: [
-            [{type:0},{type:0},{type:0}],
-            [{type:0},{type:0},{type:0}],
-            [{type:0},{type:0},{type:0}]
+            [0,0,0],
+            [0,0,0],
+            [0,0,0]
         ],
         width: 3,
         height:3,
         tileSize:1,
+        tileTypes: { FLOOR:0, WALL:1 },
         isWallAt(x,y){
             const tx = Math.floor(x/1); const ty=Math.floor(y/1);
-            return this.map[ty][tx].type===this.tileTypes.WALL;
+            return this.map[ty][tx]===this.tileTypes.WALL;
         }
     };
     const pfManager = new PathfindingManager(mapManager);
@@ -31,18 +31,18 @@ test('단순 경로 탐색', () => {
 
 test('같은 지점은 경로 없음', () => {
     const mapManager = {
-        tileTypes:{FLOOR:0,WALL:1},
         map: [
-            [{type:0},{type:0},{type:0}],
-            [{type:0},{type:0},{type:0}],
-            [{type:0},{type:0},{type:0}]
+            [0,0,0],
+            [0,0,0],
+            [0,0,0]
         ],
         width:3,
         height:3,
         tileSize:1,
+        tileTypes:{FLOOR:0,WALL:1},
         isWallAt(x,y){
             const tx=Math.floor(x/1); const ty=Math.floor(y/1);
-            return this.map[ty][tx].type===this.tileTypes.WALL;
+            return this.map[ty][tx]===this.tileTypes.WALL;
         }
     };
     const pfManager = new PathfindingManager(mapManager);
@@ -52,18 +52,18 @@ test('같은 지점은 경로 없음', () => {
 
 test('동적 장애물 회피', () => {
     const mapManager = {
-        tileTypes:{FLOOR:0,WALL:1},
         map: [
-            [{type:0},{type:0},{type:0}],
-            [{type:0},{type:0},{type:0}],
-            [{type:0},{type:0},{type:0}]
+            [0,0,0],
+            [0,0,0],
+            [0,0,0]
         ],
         width:3,
         height:3,
         tileSize:1,
+        tileTypes:{FLOOR:0,WALL:1},
         isWallAt(x,y){
             const tx=Math.floor(x/1); const ty=Math.floor(y/1);
-            return this.map[ty][tx].type===this.tileTypes.WALL;
+            return this.map[ty][tx]===this.tileTypes.WALL;
         }
     };
     const pfManager = new PathfindingManager(mapManager);
@@ -79,18 +79,18 @@ test('동적 장애물 회피', () => {
 
 test('탈출 경로 탐색', () => {
     const mapManager = {
-        tileTypes:{FLOOR:0,WALL:1},
         map: [
-            [{type:1},{type:1},{type:1}],
-            [{type:1},{type:0},{type:0}],
-            [{type:1},{type:1},{type:1}]
+            [1,1,1],
+            [1,0,0],
+            [1,1,1]
         ],
         width:3,
         height:3,
         tileSize:1,
+        tileTypes:{FLOOR:0,WALL:1},
         isWallAt(x,y){
             const tx=Math.floor(x/1); const ty=Math.floor(y/1);
-            return this.map[ty][tx].type===this.tileTypes.WALL;
+            return this.map[ty][tx]===this.tileTypes.WALL;
         }
     };
     const pfManager = new PathfindingManager(mapManager);


### PR DESCRIPTION
## Summary
- revert changes that converted map tiles to object form
- restore pathfinding and tests to work with numeric tile map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858241ce81c8327b76d12a5a2d0aee0