### PR TITLE
Add VisionEngine with geometry helpers

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -76,10 +76,12 @@ export class CompositeAI extends AIArchetype {
 // --- 전사형 AI ---
 export class MeleeAI extends AIArchetype {
     decideAction(self, context) {
-        const { enemies, targetingEngine, pathfindingManager, player, mapManager } = context;
+        const { enemies, targetingEngine, pathfindingManager, player, mapManager, visionEngine } = context;
 
         // 1. 타겟 결정
-        const visibleEnemies = enemies.filter(e => Math.hypot(e.x - self.x, e.y - self.y) < self.visionRange);
+        const visibleEnemies = visionEngine
+            ? visionEngine.getVisibleTargets(self, enemies)
+            : enemies.filter(e => Math.hypot(e.x - self.x, e.y - self.y) < self.visionRange);
 
         const mbti = self.properties?.mbti || '';
         let rule = 'closest';
@@ -306,10 +308,12 @@ export class PurifierAI extends AIArchetype {
 // --- 원거리형 AI ---
 export class RangedAI extends AIArchetype {
     decideAction(self, context) {
-        const { player, allies, enemies, mapManager, eventManager } = context;
+        const { player, allies, enemies, mapManager, eventManager, visionEngine } = context;
 
         const currentVisionRange = self.stats?.get('visionRange') ?? self.visionRange;
-        const visibleEnemies = enemies.filter(e => Math.hypot(e.x - self.x, e.y - self.y) < currentVisionRange);
+        const visibleEnemies = visionEngine
+            ? visionEngine.getVisibleTargets(self, enemies)
+            : enemies.filter(e => Math.hypot(e.x - self.x, e.y - self.y) < currentVisionRange);
         const targetList = visibleEnemies;
 
         if (targetList.length === 0) {

--- a/src/ai/VisionEngine.js
+++ b/src/ai/VisionEngine.js
@@ -1,0 +1,43 @@
+import { hasLineOfSight } from '../utils/geometry.js';
+
+export class VisionEngine {
+    constructor(mapManager) {
+        this.mapManager = mapManager;
+        console.log('[VisionEngine] Initialized');
+    }
+
+    getVisibleTargets(caster, potentialTargets = []) {
+        const visibles = [];
+        const range = caster.stats?.get('visionRange') ?? caster.visionRange;
+        for (const target of potentialTargets) {
+            const dist = Math.hypot(target.x - caster.x, target.y - caster.y);
+            if (range && dist > range) continue;
+            if (this.hasLineOfSight(caster, target)) {
+                visibles.push(target);
+            }
+        }
+        return visibles;
+    }
+
+    hasLineOfSight(startEntity, endEntity) {
+        if (!this.mapManager) return true;
+        const sx = Math.floor(startEntity.x / this.mapManager.tileSize);
+        const sy = Math.floor(startEntity.y / this.mapManager.tileSize);
+        const ex = Math.floor(endEntity.x / this.mapManager.tileSize);
+        const ey = Math.floor(endEntity.y / this.mapManager.tileSize);
+        return hasLineOfSight(sx, sy, ex, ey, this.mapManager);
+    }
+
+    updateFacingDirection(entity) {
+        let targetX = null;
+        if (entity.velocity && entity.velocity.x) {
+            targetX = entity.x + entity.velocity.x;
+        } else if (entity.currentTarget) {
+            targetX = entity.currentTarget.x;
+        }
+        if (targetX !== null) {
+            if (targetX < entity.x) entity.direction = 'left';
+            else if (targetX > entity.x) entity.direction = 'right';
+        }
+    }
+}

--- a/src/combat.js
+++ b/src/combat.js
@@ -38,7 +38,14 @@ export class CombatCalculator {
         if (!attacker || !defender) return false;
         const dx = defender.x - attacker.x;
         const dy = defender.y - attacker.y;
-        const facing = defender.direction || { x: 0, y: 1 };
+        let facing = { x: 0, y: 1 };
+        if (typeof defender.direction === 'string') {
+            facing = defender.direction === 'left' ? { x: -1, y: 0 } : { x: 1, y: 0 };
+        } else if (typeof defender.direction === 'number') {
+            facing = { x: defender.direction, y: 0 };
+        } else if (defender.direction && typeof defender.direction === 'object') {
+            facing = defender.direction;
+        }
         return (dx * facing.x + dy * facing.y) > 0;
     }
 

--- a/src/entities.js
+++ b/src/entities.js
@@ -30,6 +30,7 @@ class Entity {
         this.effects = []; // 적용중인 효과 목록 배열 추가
         this.unitType = 'generic'; // 기본 유닛 타입을 '일반'으로 설정
         this.possessedBy = null; // 빙의 상태를 저장할 속성
+        this.direction = 'right'; // 시선 방향
 
         // --- AI 상태 저장용 프로퍼티 ---
         this.aiState = null;      // 현재 AI의 상태 (예: 'retreating')
@@ -144,7 +145,8 @@ class Entity {
         // 2. 유닛 이미지 그리기 (yOffset 적용)
         ctx.translate(0, yOffset);
         ctx.rotate(rotation);
-        ctx.scale(this.direction || 1, 1);
+        const scaleX = this.direction === 'left' ? -1 : 1;
+        ctx.scale(scaleX, 1);
         if (this.image) {
             ctx.drawImage(this.image, -this.width / 2, -this.height, this.width, this.height);
         }

--- a/src/game.js
+++ b/src/game.js
@@ -41,6 +41,7 @@ import { TankerGhostAI, RangedGhostAI, SupporterGhostAI, CCGhostAI } from './ai.
 import { EMBLEMS } from './data/emblems.js';
 import { TooltipEngine } from './ui/TooltipEngine.js';
 import { TargetingEngine } from './ai/TargetingEngine.js';
+import { VisionEngine } from './ai/VisionEngine.js';
 
 export class Game {
     constructor() {
@@ -108,6 +109,7 @@ export class Game {
         this.combatCalculator = new CombatCalculator(this.eventManager, this.tagManager);
         // Player begins in the Aquarium map for feature testing
         this.mapManager = new AquariumMapManager();
+        this.visionEngine = new VisionEngine(this.mapManager);
         this.saveLoadManager = new SaveLoadManager();
         this.turnManager = new TurnManager();
         this.narrativeManager = new NarrativeManager();
@@ -1168,6 +1170,7 @@ export class Game {
             knockbackEngine: this.knockbackEngine,
             supportEngine: this.supportEngine,
             targetingEngine: this.targetingEngine,
+            visionEngine: this.visionEngine,
             assets: this.loader.assets,
             metaAIManager,
             microItemAIManager,

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -110,7 +110,15 @@ export class MetaAIManager {
                 if (!target || !mapManager || !vfxManager) break;
 
                 const fromPos = { x: entity.x, y: entity.y };
-                const behindX = target.x - (target.direction * (mapManager.tileSize * 0.8));
+                let dir = 1;
+                if (typeof target.direction === 'string') {
+                    dir = target.direction === 'left' ? -1 : 1;
+                } else if (typeof target.direction === 'number') {
+                    dir = target.direction;
+                } else if (target.direction && typeof target.direction === 'object' && typeof target.direction.x === 'number') {
+                    dir = Math.sign(target.direction.x) || 1;
+                }
+                const behindX = target.x - (dir * (mapManager.tileSize * 0.8));
                 const behindY = target.y;
                 const toPos = { x: behindX, y: behindY };
 
@@ -259,6 +267,10 @@ export class MetaAIManager {
                 
                 // AI가 행동을 결정한 직후 MBTI 엔진 처리
                 this.mbtiEngine.process(member, { ...action, context: currentContext });
+
+                if (context.visionEngine) {
+                    context.visionEngine.updateFacingDirection(member);
+                }
 
                 this.executeAction(member, action, currentContext);
             }


### PR DESCRIPTION
## Summary
- integrate geometry-based line-of-sight checks into VisionEngine
- keep entity facing with a default direction
- reuse existing hasLineOfSight helper for LOS calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68582ec1693483279cf25e87eedfadda