### PR TITLE
Add armor gear and spawn tweaks

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -64,6 +64,30 @@ export const ITEMS = {
         toughness: 4,
     },
 
+    metal_armor: {
+        name: '금속 갑옷',
+        type: 'armor',
+        tags: ['armor', 'heavy_armor'],
+        imageKey: 'metal_armor',
+        stats: { maxHp: 8 },
+        tier: 'rare',
+        durability: 150,
+        weight: 12,
+        toughness: 8,
+    },
+
+    wizard_robe: {
+        name: '마법사 로브',
+        type: 'armor',
+        tags: ['armor', 'cloth_armor'],
+        imageKey: 'wizard_robe',
+        stats: { maxHp: 3, intelligence: 2 },
+        tier: 'normal',
+        durability: 50,
+        weight: 3,
+        toughness: 2,
+    },
+
     shield_basic: {
         name: '기본 방패',
         type: 'shield',

--- a/src/data/tables.js
+++ b/src/data/tables.js
@@ -27,6 +27,11 @@ export const LOOT_DROP_TABLE = [
     { id: 'violin_bow', weight: 5 },
     { id: 'estoc', weight: 5 },
     { id: 'fox_charm', weight: 10 },
+    { id: 'shield_basic', weight: 5 },
+    { id: 'leather_armor', weight: 3 },
+    { id: 'plate_armor', weight: 2 },
+    { id: 'metal_armor', weight: 2 },
+    { id: 'wizard_robe', weight: 3 },
 ];
 
 // 확장성을 위해 몬스터 타입을 매개변수로 받아 드랍 테이블을 반환하는 함수

--- a/src/factory.js
+++ b/src/factory.js
@@ -80,6 +80,11 @@ export class CharacterFactory {
                 player.skills.push(SKILLS.fireball.id);
                 player.skills.push(SKILLS.iceball.id);
                 player.skills.push(SKILLS.teleport.id);
+                const pArmor = this.itemFactory.create('leather_armor', 0, 0, tileSize);
+                if (pArmor) {
+                    player.equipment.armor = pArmor;
+                    if (player.stats) player.stats.updateEquipmentStats();
+                }
                 return player;
             case 'mercenary':
                 if (config.jobId && JOBS[config.jobId]) {
@@ -141,6 +146,12 @@ export class CharacterFactory {
                         if (merc.stats) merc.stats.updateEquipmentStats();
                         if (typeof merc.updateAI === 'function') merc.updateAI();
                     }
+                }
+
+                const mArmor = this.itemFactory.create('leather_armor', 0, 0, tileSize);
+                if (mArmor) {
+                    merc.equipment.armor = mArmor;
+                    if (merc.stats) merc.stats.updateEquipmentStats();
                 }
 
                 return merc;

--- a/src/game.js
+++ b/src/game.js
@@ -74,6 +74,8 @@ export class Game {
         this.loader.loadImage('arrow', 'assets/images/arrow.png');
         this.loader.loadImage('leather_armor', 'assets/images/leatherarmor.png');
         this.loader.loadImage('plate-armor', 'assets/images/plate-armor.png');
+        this.loader.loadImage('metal_armor', 'assets/images/metal.png');
+        this.loader.loadImage('wizard_robe', 'assets/images/wizard.png');
         this.loader.loadImage('violin-bow', 'assets/images/violin-bow.png');
         this.loader.loadImage('skeleton', 'assets/images/skeleton.png');
         this.loader.loadImage('pet-fox', 'assets/images/pet-fox.png');
@@ -380,7 +382,7 @@ export class Game {
         if(emblemConductor) this.itemManager.addItem(emblemConductor);
 
         // === 3. 몬스터 생성 ===
-        const baseMonsterCount = this.mapManager.name === 'aquarium' ? 10 : 40;
+        const baseMonsterCount = this.mapManager.name === 'aquarium' ? 30 : 40;
         this.spawningEngine.spawnInitial(baseMonsterCount);
 
         // === 4. 용병 고용 로직 ===

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -99,6 +99,13 @@ export class AquariumManager {
                 if (weapon) {
                     this.equipmentManager.equip(monster, weapon, null);
 
+                    const armorOptions = ['leather_armor', 'plate_armor', 'metal_armor', 'wizard_robe'];
+                    const armorId = armorOptions[Math.floor(Math.random() * armorOptions.length)];
+                    const armor = this.itemFactory.create(armorId, 0, 0, 1);
+                    if (armor) {
+                        this.equipmentManager.equip(monster, armor, null);
+                    }
+
                     const tags = weapon.tags || [];
                     const isMelee = tags.includes('melee') && !tags.includes('ranged');
                     const excluded = tags.includes('spear') || tags.includes('scythe');
@@ -108,16 +115,16 @@ export class AquariumManager {
                         equipShield = true;
                     }
 
-                    if (isMelee && !excluded && equipShield) {
-                        const shield = this.itemFactory.create('shield_basic', 0, 0, 1);
-                        if (shield) {
-                            this.equipmentManager.equip(monster, shield, null);
-                            shieldSpawned = true;
+                        if (isMelee && !excluded && equipShield) {
+                            const shield = this.itemFactory.create('shield_basic', 0, 0, 1);
+                            if (shield) {
+                                this.equipmentManager.equip(monster, shield, null);
+                                shieldSpawned = true;
+                            }
                         }
                     }
                 }
             }
-        }
     }
 
     addTestingFeature(feature) {
@@ -149,6 +156,13 @@ export class AquariumManager {
                     const weapon = this.itemFactory.create(randomWeaponId, 0, 0, 1);
                     if (weapon) {
                         this.equipmentManager.equip(monster, weapon, null);
+
+                        const armorChoices = ['leather_armor', 'plate_armor', 'metal_armor', 'wizard_robe'];
+                        const armorId = armorChoices[Math.floor(Math.random() * armorChoices.length)];
+                        const armor = this.itemFactory.create(armorId, 0, 0, 1);
+                        if (armor) {
+                            this.equipmentManager.equip(monster, armor, null);
+                        }
 
                         // 근거리 무기(창, 낫 제외)를 들고 있을 때 확률적으로 방패 장착
                         const tags = weapon.tags || [];

--- a/src/systems/SpawningEngine.js
+++ b/src/systems/SpawningEngine.js
@@ -104,6 +104,20 @@ export class SpawningEngine {
             this.equipmentManager.equip(monster, weapon, null);
         }
 
+        const armorChoices = ['leather_armor', 'plate_armor', 'metal_armor', 'wizard_robe'];
+        const armorId = armorChoices[Math.floor(Math.random() * armorChoices.length)];
+        const armor = this.factory.itemFactory.create(armorId, 0, 0, this.mapManager.tileSize);
+        if (armor) {
+            this.equipmentManager.equip(monster, armor, null);
+        }
+
+        if (Math.random() < 0.5) {
+            const shield = this.factory.itemFactory.create('shield_basic', 0, 0, this.mapManager.tileSize);
+            if (shield) {
+                this.equipmentManager.equip(monster, shield, null);
+            }
+        }
+
         const consumableId = rollOnTable(getMonsterLootTable('monster'));
         const consumable = this.factory.itemFactory.create(consumableId, 0, 0, this.mapManager.tileSize);
         if (consumable && consumable.tags.includes('consumable')) {


### PR DESCRIPTION
## Summary
- add metal armor and wizard robe items
- load new armor images
- give player, mercenaries and monsters starting armor
- let some monsters carry shields and drop armor
- triple aquarium monster count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68583601436c8327a45b29789c385bd7