### PR TITLE
Add equipment to quantum monster activation

### DIFF
--- a/src/managers/QuantumManager.js
+++ b/src/managers/QuantumManager.js
@@ -1,0 +1,44 @@
+import { QuantumEngine } from '../systems/QuantumEngine.js';
+
+export class QuantumManager {
+    constructor(factory, monsterManager, metaAIManager, equipmentManager = null, parasiteManager = null, traitManager = null, mapManager = null) {
+        this.potentialMonsters = [];
+        this.engine = new QuantumEngine(
+            factory,
+            monsterManager,
+            metaAIManager,
+            equipmentManager,
+            parasiteManager,
+            traitManager,
+            mapManager
+        );
+        this.mapManager = mapManager;
+        console.log('[QuantumManager] Initialized with internal QuantumEngine.');
+    }
+
+    /**
+     * 잠재적 몬스터 정보를 등록합니다.
+     * @param {object} monsterData
+     */
+    registerPotentialMonster(monsterData) {
+        this.potentialMonsters.push(monsterData);
+    }
+
+    /**
+     * 매 프레임 호출될 업데이트 함수. 활성화 처리를 엔진에 위임합니다.
+     * @param {object} fogManager
+     */
+    update(fogManager) {
+        if (this.potentialMonsters.length === 0) return;
+
+        const result = this.engine.processActivations(this.potentialMonsters, fogManager);
+
+        if (result.activatedIndexes.length > 0) {
+            for (let i = result.activatedIndexes.length - 1; i >= 0; i--) {
+                const indexToRemove = result.activatedIndexes[i];
+                this.potentialMonsters.splice(indexToRemove, 1);
+            }
+            console.log(`[QuantumManager] Activated ${result.newlyActivated.length} monsters via engine.`);
+        }
+    }
+}

--- a/src/managers/fogManager.js
+++ b/src/managers/fogManager.js
@@ -5,9 +5,10 @@ import { hasLineOfSight } from '../utils/geometry.js';
 export const FOG_STATE = { UNSEEN: 0, SEEN: 1, VISIBLE: 2 };
 
 export class FogManager {
-    constructor(width, height) {
+    constructor(width, height, tileSize = 32) {
         this.width = width;
         this.height = height;
+        this.tileSize = tileSize;
         // 모든 타일을 '본 적 없는' 상태로 초기화
         this.fogMap = Array.from({ length: height }, () => Array(width).fill(FOG_STATE.UNSEEN));
     }
@@ -62,5 +63,9 @@ export class FogManager {
                 }
             }
         }
+    }
+
+    isVisible(tileX, tileY) {
+        return this.fogMap[tileY]?.[tileX] === FOG_STATE.VISIBLE;
     }
 }

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -26,6 +26,7 @@ import { SynergyManager } from '../micro/SynergyManager.js';
 import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
 import { PossessionAIManager } from './possessionAIManager.js';
+import { QuantumManager } from './QuantumManager.js';
 // 파일 기반 로거는 Node 환경 전용이라 기본 묶음에서 제외한다
 // import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
@@ -54,6 +55,7 @@ export {
     MetaAIManager,
     PossessionAIManager,
     AuraManager,
+    QuantumManager,
     SynergyManager,
     SpeechBubbleManager,
 };

--- a/src/systems/QuantumEngine.js
+++ b/src/systems/QuantumEngine.js
@@ -1,0 +1,104 @@
+import { rollOnTable } from '../utils/random.js';
+import { getMonsterLootTable } from '../data/tables.js';
+import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
+import { TRAITS } from '../data/traits.js';
+
+export class QuantumEngine {
+    constructor(factory, monsterManager, metaAIManager, equipmentManager = null, parasiteManager = null, traitManager = null, mapManager = null) {
+        this.factory = factory;
+        this.monsterManager = monsterManager;
+        this.metaAIManager = metaAIManager;
+        this.equipmentManager = equipmentManager;
+        this.parasiteManager = parasiteManager;
+        this.traitManager = traitManager;
+        this.mapManager = mapManager;
+    }
+
+    /**
+     * 잠재적 몬스터 목록을 받아, 활성화 조건을 만족하는 몬스터들을 실체화합니다.
+     * @param {Array<object>} potentialMonsters - 검사할 잠재적 몬스터 데이터 목록
+     * @param {object} fogManager - 안개 정보
+     * @returns {{newlyActivated: Array<object>, activatedIndexes: Array<number>}}
+     */
+    processActivations(potentialMonsters, fogManager) {
+        const newlyActivated = [];
+        const activatedIndexes = [];
+        const TILE_SIZE = fogManager.tileSize;
+
+        potentialMonsters.forEach((data, index) => {
+            const tileX = Math.floor(data.x / TILE_SIZE);
+            const tileY = Math.floor(data.y / TILE_SIZE);
+
+            // 1. 활성화 조건 검사: 안개가 걷혔는가?
+            if (fogManager.isVisible(tileX, tileY)) {
+                const monsterType = data.monsterType || 'monster';
+                let baseStats = { ...(data.baseStats || {}) };
+                if (this.mapManager && this.mapManager.name === 'aquarium') {
+                    baseStats = adjustMonsterStatsForAquarium(baseStats);
+                }
+
+                const monster = this.factory.create(monsterType, {
+                    ...data,
+                    baseStats,
+                    tileSize: data.tileSize || TILE_SIZE,
+                    image: data.image || this.factory.assets[monsterType] || this.factory.assets.monster,
+                    groupId: data.groupId || 'dungeon_monsters',
+                });
+
+                if (this.traitManager) {
+                    this.traitManager.applyTraits(monster, TRAITS);
+                }
+
+                if (this.equipmentManager) {
+                    this._equipInitialGear(monster, monsterType);
+                }
+
+                if (this.monsterManager.add) {
+                    this.monsterManager.add(monster);
+                } else {
+                    this.monsterManager.monsters.push(monster);
+                }
+                this.metaAIManager.getGroup(monster.groupId)?.addMember(monster);
+
+                newlyActivated.push(monster);
+                activatedIndexes.push(index);
+            }
+        });
+
+        return { newlyActivated, activatedIndexes };
+    }
+
+    _equipInitialGear(monster, monsterType) {
+        const weaponId = rollOnTable(getMonsterLootTable(monsterType));
+        const weapon = this.factory.itemFactory.create(weaponId, 0, 0, monster.tileSize);
+        if (weapon && (weapon.type === 'weapon' || weapon.tags?.includes('weapon'))) {
+            this.equipmentManager.equip(monster, weapon, null);
+        }
+
+        const armorChoices = ['leather_armor', 'plate_armor', 'metal_armor', 'wizard_robe'];
+        const armorId = armorChoices[Math.floor(Math.random() * armorChoices.length)];
+        const armor = this.factory.itemFactory.create(armorId, 0, 0, monster.tileSize);
+        if (armor) {
+            this.equipmentManager.equip(monster, armor, null);
+        }
+
+        if (Math.random() < 0.5) {
+            const shield = this.factory.itemFactory.create('shield_basic', 0, 0, monster.tileSize);
+            if (shield) {
+                this.equipmentManager.equip(monster, shield, null);
+            }
+        }
+
+        const consumableId = rollOnTable(getMonsterLootTable(monsterType));
+        const consumable = this.factory.itemFactory.create(consumableId, 0, 0, monster.tileSize);
+        if (consumable && consumable.tags?.includes('consumable')) {
+            monster.addConsumable(consumable);
+        }
+
+        if (this.parasiteManager && Math.random() < 0.15) {
+            const pid = Math.random() < 0.5 ? 'parasite_leech' : 'parasite_worm';
+            const pItem = this.factory.itemFactory.create(pid, 0, 0, monster.tileSize);
+            if (pItem) this.parasiteManager.equip(monster, pItem);
+        }
+    }
+}

--- a/src/systems/SpawningEngine.js
+++ b/src/systems/SpawningEngine.js
@@ -1,133 +1,48 @@
-import { rollOnTable } from '../utils/random.js';
-import { getMonsterLootTable } from '../data/tables.js';
-import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
-import { TRAITS } from '../data/traits.js';
-
 export class SpawningEngine {
-    constructor(monsterManager, factory, mapManager, equipmentManager, parasiteManager, equipmentRenderManager = null) {
-        this.monsterManager = monsterManager;
-        this.factory = factory;
+    constructor(quantumManager, mapManager) {
+        this.quantumManager = quantumManager;
         this.mapManager = mapManager;
-        this.equipmentManager = equipmentManager;
-        this.parasiteManager = parasiteManager;
-        this.equipmentRenderManager = equipmentRenderManager;
         console.log('[SpawningEngine] Initialized');
     }
 
     spawnInitial(count) {
-        const monsters = [];
+        let registeredCount = 0;
         for (let i = 0; i < count; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
             if (!pos) continue;
 
-            let stats = {};
-            if (this.mapManager.name === 'aquarium') {
-                stats = adjustMonsterStatsForAquarium(stats);
-            }
-
-            const monster = this.factory.create('monster', {
+            const data = {
                 x: pos.x,
                 y: pos.y,
                 tileSize: this.mapManager.tileSize,
+                monsterType: 'monster',
                 groupId: 'dungeon_monsters',
-                image: this.factory.assets.monster,
-                baseStats: stats
-            });
-
-            if (this.monsterManager.traitManager) {
-                this.monsterManager.traitManager.applyTraits(monster, TRAITS);
-            }
-
-            if (this.equipmentRenderManager) {
-                monster.equipmentRenderManager = this.equipmentRenderManager;
-            }
-
-            this._equipInitialGear(monster);
-            monsters.push(monster);
+                image: null,
+                baseStats: {},
+            };
+            this.quantumManager.registerPotentialMonster(data);
+            registeredCount++;
         }
-
-        this.monsterManager.monsters.push(...monsters);
-
-        if (this.monsterManager.metaAI) {
-            const group = this.monsterManager.metaAI.groups['dungeon_monsters'];
-            if (group) monsters.forEach(m => group.addMember(m));
-        }
-
-        console.log(`[SpawningEngine] Spawned ${monsters.length} initial monsters.`);
+        console.log(`[SpawningEngine] Registered ${registeredCount} potential monsters.`);
     }
 
     spawnWave({ count = 1, monsterType = 'monster', groupId = 'dungeon_monsters', image = null }) {
-        const monsters = [];
+        let registeredCount = 0;
         for (let i = 0; i < count; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
             if (!pos) continue;
-
-            const monster = this.factory.create(monsterType, {
+            const data = {
                 x: pos.x,
                 y: pos.y,
                 tileSize: this.mapManager.tileSize,
+                monsterType,
                 groupId,
-                image: image || this.factory.assets[monsterType] || this.factory.assets.monster,
-            });
-
-            if (this.monsterManager.traitManager) {
-                this.monsterManager.traitManager.applyTraits(monster, TRAITS);
-            }
-
-            if (this.equipmentRenderManager) {
-                monster.equipmentRenderManager = this.equipmentRenderManager;
-            }
-
-            this._equipInitialGear(monster);
-            monsters.push(monster);
+                image: image,
+                baseStats: {},
+            };
+            this.quantumManager.registerPotentialMonster(data);
+            registeredCount++;
         }
-
-        this.monsterManager.monsters.push(...monsters);
-
-        if (this.monsterManager.metaAI) {
-            const group = this.monsterManager.metaAI.groups[groupId];
-            if (group) monsters.forEach(m => group.addMember(m));
-        }
-
-        console.log(`[SpawningEngine] Spawned wave of ${monsters.length} ${monsterType}.`);
-    }
-
-    _equipInitialGear(monster) {
-        if (!monster) return;
-
-        monster.consumables = [];
-        monster.consumableCapacity = 4;
-
-        const weaponId = rollOnTable(getMonsterLootTable('monster'));
-        const weapon = this.factory.itemFactory.create(weaponId, 0, 0, this.mapManager.tileSize);
-        if (weapon && (weapon.type === 'weapon' || weapon.tags.includes('weapon'))) {
-            this.equipmentManager.equip(monster, weapon, null);
-        }
-
-        const armorChoices = ['leather_armor', 'plate_armor', 'metal_armor', 'wizard_robe'];
-        const armorId = armorChoices[Math.floor(Math.random() * armorChoices.length)];
-        const armor = this.factory.itemFactory.create(armorId, 0, 0, this.mapManager.tileSize);
-        if (armor) {
-            this.equipmentManager.equip(monster, armor, null);
-        }
-
-        if (Math.random() < 0.5) {
-            const shield = this.factory.itemFactory.create('shield_basic', 0, 0, this.mapManager.tileSize);
-            if (shield) {
-                this.equipmentManager.equip(monster, shield, null);
-            }
-        }
-
-        const consumableId = rollOnTable(getMonsterLootTable('monster'));
-        const consumable = this.factory.itemFactory.create(consumableId, 0, 0, this.mapManager.tileSize);
-        if (consumable && consumable.tags.includes('consumable')) {
-            monster.addConsumable(consumable);
-        }
-
-        if (this.parasiteManager && Math.random() < 0.15) {
-            const pid = Math.random() < 0.5 ? 'parasite_leech' : 'parasite_worm';
-            const pItem = this.factory.itemFactory.create(pid, 0, 0, this.mapManager.tileSize);
-            if (pItem) this.parasiteManager.equip(monster, pItem);
-        }
+        console.log(`[SpawningEngine] Registered wave of ${registeredCount} ${monsterType}.`);
     }
 }


### PR DESCRIPTION
## Summary
- refine `QuantumEngine` to equip monsters when activated
- pass equipment and parasite managers into `QuantumManager`
- spawn potential monsters with more metadata
- initialize `QuantumManager` with new dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685843d416b88327a1a91d55e23bb456