### PR TITLE
Implement getGroup accessor in MetaAIManager

### DIFF
--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -41,6 +41,16 @@ export class MetaAIManager {
         }
         return this.groups[id];
     }
+
+    /**
+     * 그룹을 조회합니다.
+     * 존재하지 않으면 null을 반환합니다.
+     * @param {string} id
+     * @returns {AIGroup|null}
+     */
+    getGroup(id) {
+        return this.groups[id] || null;
+    }
     
     setGroupStrategy(id, strategy) {
         if (this.groups[id]) {


### PR DESCRIPTION
## Summary
- expose `getGroup` to retrieve AI groups
- use new method in `QuantumEngine`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685849064ec88327a0945fa43f5f17c7