### PR TITLE
Fix ally follow logic and monster equipment rendering

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -80,7 +80,22 @@ export class CompositeAI extends AIArchetype {
 export class MeleeAI extends AIArchetype {
     // MetaAIManager가 타겟을 지정해 주므로, 여기서는 그 타겟을 어떻게 추적할지만 판단한다.
     decideAction(self, target, context) {
-        const { aiPathfindingEngine } = context;
+        const { aiPathfindingEngine, player, allies, mapManager } = context;
+        if (!target && self.isFriendly && !self.isPlayer && player) {
+            const wander = this._getWanderPosition(
+                self,
+                player,
+                allies || [],
+                mapManager
+            );
+            if (
+                Math.hypot(wander.x - self.x, wander.y - self.y) >
+                self.tileSize * 0.3
+            ) {
+                return { type: 'move', target: wander };
+            }
+        }
+
         return aiPathfindingEngine
             ? aiPathfindingEngine.decideAction(self, target, context)
             : { type: 'idle' };

--- a/src/game.js
+++ b/src/game.js
@@ -174,6 +174,7 @@ export class Game {
         this.speechBubbleManager = this.managers.SpeechBubbleManager;
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
+        this.monsterManager.setEquipmentRenderManager(this.equipmentRenderManager);
         this.traitManager = this.managers.TraitManager;
         this.mercenaryManager.setTraitManager(this.traitManager);
         this.monsterManager.setTraitManager(this.traitManager);

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -19,6 +19,7 @@ export class MonsterManager {
         }
         this.monsters = [];
         this.traitManager = null;
+        this.equipmentRenderManager = null;
         console.log("[MonsterManager] Initialized");
 
         if (this.eventManager) {
@@ -34,6 +35,17 @@ export class MonsterManager {
 
     setTraitManager(traitManager) {
         this.traitManager = traitManager;
+    }
+
+    add(monster) {
+        if (this.equipmentRenderManager) {
+            monster.equipmentRenderManager = this.equipmentRenderManager;
+        }
+        this.monsters.push(monster);
+    }
+
+    setEquipmentRenderManager(manager) {
+        this.equipmentRenderManager = manager;
     }
 
     _spawnMonsters(count) {
@@ -52,7 +64,7 @@ export class MonsterManager {
                     image: this.assets?.monster,
                     baseStats: stats
                 });
-                this.monsters.push(monster);
+                this.add(monster);
             }
         }
     }

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -35,13 +35,13 @@ test('MeleeAI - 이동 결정', () => {
 
 // 아군이 플레이어를 따라가는지 확인
 
-test('MeleeAI - 목줄 범위 내에서는 대기', () => {
+test('MeleeAI - 목줄 범위 내에서는 플레이어를 따라 이동', () => {
     const ai = new MeleeAI();
     const self = { x: 0, y: 0, visionRange: 100, attackRange: 10, speed: 5, tileSize: 1, isFriendly: true, isPlayer: false };
     const player = { x: 10, y: 0 };
     const context = { player, allies: [], enemies: [], mapManager: mapStub };
     const action = ai.decideAction(self, null, context);
-    assert.strictEqual(action.type, 'idle');
+    assert.strictEqual(action.type, 'move');
 });
 
 // RangedAI specific behavior


### PR DESCRIPTION
## Summary
- allow `MeleeAI` allies to move near the player when idle
- track an `EquipmentRenderManager` for monsters so their gear is drawn
- wire monster render manager in `Game` setup
- adjust corresponding AI test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68584b74c89483279a46ba58d3d6dec2