### PR TITLE
Fix crash when damaged entity lacks effects

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -629,17 +629,21 @@ export class Game {
         });
 
         eventManager.subscribe('entity_damaged', (data) => {
-            this.vfxManager.flashEntity(data.defender);
+            if (data.defender) {
+                this.vfxManager.flashEntity(data.defender);
 
-            // 수면 상태인지 확인
-            const sleepEffect = data.defender.effects.find(e => e.id === 'sleep');
-            if (sleepEffect) {
-                const hitsToWake = sleepEffect.wakeUpOnHit || 1;
-                sleepEffect.hitsTaken = (sleepEffect.hitsTaken || 0) + 1;
+                // 수면 상태인지 확인
+                if (Array.isArray(data.defender.effects)) {
+                    const sleepEffect = data.defender.effects.find(e => e.id === 'sleep');
+                    if (sleepEffect) {
+                        const hitsToWake = sleepEffect.wakeUpOnHit || 1;
+                        sleepEffect.hitsTaken = (sleepEffect.hitsTaken || 0) + 1;
 
-                if (sleepEffect.hitsTaken >= hitsToWake) {
-                    this.effectManager.removeEffect(data.defender, sleepEffect);
-                    this.eventManager.publish('log', { message: `\uD83D\uDCA4 ${data.defender.constructor.name}\uC774(가) 공격을 받고 깨어났습니다!`, color: 'yellow' });
+                        if (sleepEffect.hitsTaken >= hitsToWake) {
+                            this.effectManager.removeEffect(data.defender, sleepEffect);
+                            this.eventManager.publish('log', { message: `\uD83D\uDCA4 ${data.defender.constructor.name}\uC774(가) 공격을 받고 깨어났습니다!`, color: 'yellow' });
+                        }
+                    }
                 }
             }
         });

--- a/src/managers/movementManager.js
+++ b/src/managers/movementManager.js
@@ -84,12 +84,15 @@ export class MovementManager {
         }
     }
 
-    _isOccupied(x, y, self, context) {
+    _isOccupied(x, y, self, context = {}) {
         // 벽 충돌은 기존과 동일하게 우선 확인한다.
         if (this.mapManager.isWallAt(x, y, self.width, self.height)) return true;
 
         // 모든 유닛을 대상으로 충돌을 검사하여 서로를 장애물로 인식하도록 한다.
-        const allEntities = [context.player, ...context.mercenaryManager.mercenaries, ...context.monsterManager.monsters];
+        const allEntities = [];
+        if (context.player) allEntities.push(context.player);
+        if (context.mercenaryManager?.mercenaries) allEntities.push(...context.mercenaryManager.mercenaries);
+        if (context.monsterManager?.monsters) allEntities.push(...context.monsterManager.monsters);
 
         for (const other of allEntities) {
             if (other === self) continue;

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -651,6 +651,7 @@ export class VFXManager {
                 ctx.restore();
             } else if (effect.type === 'flash') {
                 const { entity } = effect;
+                if (!entity || !entity.image) return;
                 ctx.save();
                 ctx.drawImage(entity.image, entity.x, entity.y, entity.width, entity.height);
                 ctx.globalCompositeOperation = 'source-atop';


### PR DESCRIPTION
## Summary
- prevent crash when `entity_damaged` event fires for defender without `effects`
- skip VFX flash if entity image missing
- guard movement manager collision check when context is undefined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585916f32c832789169125ea80027a